### PR TITLE
Overwrite the printed caller with a correct one

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -72,12 +72,16 @@ func newLogger(w zapcore.WriteSyncer) *zap.Logger {
 	enc := zapcore.NewConsoleEncoder(conf)
 	core := zapcore.NewCore(enc, w, Level)
 
-	return zap.New(core)
+	return zap.New(core, zap.AddCaller())
 }
 
 // Write logs all messages as logs via o.
 func (o testOutput) Write(p []byte) (int, error) {
-	msg := strings.TrimSpace(string(p))
+	// The escape sequence clears the line before writing the log message.
+	// This is unfortunately necessary as we can't call t.Helper() from all of
+	// zap's logging functions, which means t.Log will include an incorrect
+	// caller
+	msg := "\x1b[2K\r" + strings.TrimSpace(string(p))
 	o.Log(msg)
 	return len(p), nil
 }


### PR DESCRIPTION
Add a VT100 escape sequencer to clear the line so the incorrect caller gets replaced, and have zap include the caller itself
